### PR TITLE
ci: update

### DIFF
--- a/.github/workflows/nx.yml
+++ b/.github/workflows/nx.yml
@@ -9,7 +9,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v3

--- a/apps/webapp/src/app/workers/lp-solver.worker.ts
+++ b/apps/webapp/src/app/workers/lp-solver.worker.ts
@@ -1,5 +1,3 @@
-/// <reference lib="webworker" />
-
 import { expose } from 'comlink'
 import { solve, Model } from 'yalps'
 


### PR DESCRIPTION
https://github.com/isoden/ya-mhrs-sim/actions/runs/4154264732/jobs/7186521970

```console
FAIL src/app/my-armors/my-armors-page/components/my-armors-page/my-armors-page.component.spec.ts
  ● Test suite failed to run

    apps/webapp/src/app/my-armors/my-armors-page/components/my-armors-page/my-armors-page.component.ts:59:21 - error TS2339: Property 'clipboard' does not exist on type 'WorkerNavigator'.

    59     await navigator.clipboard.writeText(csv)
```

CI 環境でのみ `navigator.clipboard` を参照している箇所で TypeScript のエラーがでていた。 
エラー元の `my-armors-page.component.ts` とは直接関係ないが、 `lp-solver.worker.ts` では triple slash directive を使って `webworker` の型定義を読み込んでおり、 これを削除するとエラーは消えた。
